### PR TITLE
Test version with `vim`, not `ex`

### DIFF
--- a/lib/Text/VimColour.pm
+++ b/lib/Text/VimColour.pm
@@ -11,8 +11,8 @@ class Text::VimColour:ver<0.4> {
 
     proto method BUILD(|z) {
         ENTER {
-            my $version = .[0] given split /','/, q:x/ex --version/;
-            die "didn't find a recent vim/ex"  unless $version ~~ /' Vi IMproved 7.4 '/;
+            my $version = .[0] given split /','/, q:x/vim --version/;
+            die "didn't find a recent vim"  unless $version ~~ /' Vi IMproved 7.4 '/;
             callsame;
         }
         {*}


### PR DESCRIPTION
Since `vim` is the actual command used later on, it's also what should be tested for. The `ex` found may not be related to the `vim` that is installed at all, causing unnecessary failures.
